### PR TITLE
Add a yarn install step

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -16,5 +16,5 @@ echo Project ID $PROJECTID
 gcloud config set project $PROJECTID
 
 rm -rf ./build
-cd client && yarn build && cd ..
+cd client && yarn install && yarn build && cd ..
 gcloud app deploy -q app.yaml cron.yaml queue.yaml


### PR DESCRIPTION
Currently the deploy script fails because `yarn install` has not been run.