### PR TITLE
fix: make root window scrollable

### DIFF
--- a/client/src/modules/components/AppFrame.js
+++ b/client/src/modules/components/AppFrame.js
@@ -53,7 +53,7 @@ const styles = (theme) => ({
     width: '100%',
     height: '100%',
     zIndex: 1,
-    overflow: 'hidden',
+    overflow: 'scroll',
     display: 'flex',
   },
   appBar: {


### PR DESCRIPTION
Make the root div scrollable to it is not cut off on smaller screens.

Thanks to @gururajahegde for pointing this out.

resolves #47