### PR TITLE
feat: display spinner while loading

### DIFF
--- a/client/src/pages/Policy/PolicyList.js
+++ b/client/src/pages/Policy/PolicyList.js
@@ -22,6 +22,7 @@ import AddIcon from '@material-ui/icons/Add';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 // Lodash
 import map from 'lodash/map';
@@ -60,6 +61,7 @@ class PolicyList extends React.Component {
       policies: [],
       selected: [],
       order: 'asc',
+      isLoading: false,
     };
 
     this.policyService = new PolicyService();
@@ -98,9 +100,11 @@ class PolicyList extends React.Component {
   };
 
   refreshList = async () => {
+    this.setState({ isLoading: true });
     const policies = await this.policyService.list();
     this.setState({
       policies,
+      isLoading: false,
     });
   };
 
@@ -244,37 +248,48 @@ class PolicyList extends React.Component {
               </TableRow>
             </TableHead>
             <TableBody>
-              {map(policies, (policy) => {
-                const isSelected = indexOf(selected, policy) !== -1;
-                return (
-                  <TableRow
-                    hover
-                    role="checkbox"
-                    aria-checked={isSelected}
-                    tabIndex={-1}
-                    key={policy}
-                    selected={isSelected}
-                  >
-                    <TableCell padding="none" className={classes.checkboxCell}>
-                      <Checkbox
-                        checked={isSelected}
-                        onClick={(event) => this.handleClick(event, policy)}
-                      />
-                    </TableCell>
-
-                    <TableCell>
-                      <span
-                        onClick={this.handleClickNavigate(
-                          `/policies/browser/${policy}`
-                        )}
-                        className={classes.link}
+              {this.state.isLoading ? (
+                <TableRow>
+                  <TableCell colSpan="2">
+                    <CircularProgress />
+                  </TableCell>
+                </TableRow>
+              ) : (
+                map(policies, (policy) => {
+                  const isSelected = indexOf(selected, policy) !== -1;
+                  return (
+                    <TableRow
+                      hover
+                      role="checkbox"
+                      aria-checked={isSelected}
+                      tabIndex={-1}
+                      key={policy}
+                      selected={isSelected}
+                    >
+                      <TableCell
+                        padding="none"
+                        className={classes.checkboxCell}
                       >
-                        {policy}
-                      </span>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
+                        <Checkbox
+                          checked={isSelected}
+                          onClick={(event) => this.handleClick(event, policy)}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <span
+                          onClick={this.handleClickNavigate(
+                            `/policies/browser/${policy}`
+                          )}
+                          className={classes.link}
+                        >
+                          {policy}
+                        </span>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
             </TableBody>
           </Table>
         </AppPageContent>

--- a/client/src/pages/Schedule/ScheduleList.js
+++ b/client/src/pages/Schedule/ScheduleList.js
@@ -21,6 +21,7 @@ import AddIcon from '@material-ui/icons/Add';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import EditIcon from '@material-ui/icons/Edit';
 import DeleteIcon from '@material-ui/icons/Delete';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 // Lodash
 import map from 'lodash/map';
@@ -59,6 +60,7 @@ class ScheduleList extends React.Component {
       schedules: [],
       selected: [],
       order: 'asc',
+      isLoading: false,
     };
 
     this.scheduleService = new ScheduleService();
@@ -97,9 +99,11 @@ class ScheduleList extends React.Component {
   };
 
   refreshList = async () => {
+    this.setState({ isLoading: true });
     const schedules = await this.scheduleService.list();
     this.setState({
       schedules,
+      isLoading: false,
     });
   };
 
@@ -243,37 +247,48 @@ class ScheduleList extends React.Component {
               </TableRow>
             </TableHead>
             <TableBody>
-              {map(schedules, (schedule) => {
-                const isSelected = indexOf(selected, schedule) !== -1;
-                return (
-                  <TableRow
-                    hover
-                    role="checkbox"
-                    aria-checked={isSelected}
-                    tabIndex={-1}
-                    key={schedule}
-                    selected={isSelected}
-                  >
-                    <TableCell padding="none" className={classes.checkboxCell}>
-                      <Checkbox
-                        checked={isSelected}
-                        onClick={(event) => this.handleClick(event, schedule)}
-                      />
-                    </TableCell>
-
-                    <TableCell>
-                      <span
-                        onClick={this.handleClickNavigate(
-                          `/schedules/browser/${schedule}`
-                        )}
-                        className={classes.link}
+              {this.state.isLoading ? (
+                <TableRow>
+                  <TableCell colSpan="2">
+                    <CircularProgress />
+                  </TableCell>
+                </TableRow>
+              ) : (
+                map(schedules, (schedule) => {
+                  const isSelected = indexOf(selected, schedule) !== -1;
+                  return (
+                    <TableRow
+                      hover
+                      role="checkbox"
+                      aria-checked={isSelected}
+                      tabIndex={-1}
+                      key={schedule}
+                      selected={isSelected}
+                    >
+                      <TableCell
+                        padding="none"
+                        className={classes.checkboxCell}
                       >
-                        {schedule}
-                      </span>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
+                        <Checkbox
+                          checked={isSelected}
+                          onClick={(event) => this.handleClick(event, schedule)}
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        <span
+                          onClick={this.handleClickNavigate(
+                            `/schedules/browser/${schedule}`
+                          )}
+                          className={classes.link}
+                        >
+                          {schedule}
+                        </span>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
             </TableBody>
           </Table>
         </AppPageContent>


### PR DESCRIPTION
Display a circular progress indicator while loading schedule and policy lists.
Not the prettiest thing in the world, but confirmed to work using network link conditioner.
