### PR TITLE
feat: support displayname in gui

### DIFF
--- a/client/src/modules/api/policy.js
+++ b/client/src/modules/api/policy.js
@@ -1,6 +1,6 @@
 class PolicyService {
   list = async () => {
-    const response = await fetch(`/api/v1/list_policies`, {
+    const response = await fetch(`/api/v1/list_policies?verbose=true`, {
       method: 'GET',
       credentials: 'same-origin',
     });

--- a/client/src/modules/api/schedule.js
+++ b/client/src/modules/api/schedule.js
@@ -1,6 +1,6 @@
 class ScheduleService {
   list = async () => {
-    const response = await fetch(`/api/v1/list_schedules`, {
+    const response = await fetch(`/api/v1/list_schedules?verbose=true`, {
       method: 'GET',
       credentials: 'same-origin',
     });

--- a/client/src/modules/utils/policy.js
+++ b/client/src/modules/utils/policy.js
@@ -1,6 +1,8 @@
 export const getDefaultPolicy = () => ({
   name: '',
 
+  displayname: '',
+
   // array of strings
   projects: [],
 

--- a/client/src/modules/utils/schedule.js
+++ b/client/src/modules/utils/schedule.js
@@ -1,5 +1,6 @@
 export const getDefaultSchedule = () => ({
   name: '',
+  displayname: '',
   timezone: 'UTC',
   Shape: [7, 24],
   dtype: 'int64',

--- a/client/src/pages/Policy/Policy.js
+++ b/client/src/pages/Policy/Policy.js
@@ -12,6 +12,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 // Lodash
 import map from 'lodash/map';
@@ -34,12 +35,13 @@ const styles = (theme) => ({
     marginRight: theme.spacing(2),
   },
   textField: {
-    width: 250,
+    width: 450,
     marginBottom: theme.spacing(3),
+    marginRight: theme.spacing(2),
   },
   formControl: {
-    width: 250,
-    marginBottom: theme.spacing(3),
+    width: 450,
+    marginBottom: theme.spacing(4),
   },
 });
 
@@ -49,6 +51,7 @@ class Policy extends React.Component {
     this.state = {
       policy: null,
       schedules: null,
+      isLoading: false,
 
       nameError: false,
       scheduleError: false,
@@ -63,6 +66,7 @@ class Policy extends React.Component {
   async componentDidMount() {
     try {
       const { match } = this.props;
+      this.setState({ isLoading: true });
       const schedules = await this.scheduleService.list();
       let policy;
       if (match.params.policy) {
@@ -70,12 +74,13 @@ class Policy extends React.Component {
       } else {
         policy = getDefaultPolicy();
         if (schedules && schedules.length) {
-          policy.schedulename = schedules[0];
+          policy.schedulename = schedules[0].name;
         }
       }
       this.setState({
         policy,
         schedules,
+        isLoading: false,
       });
     } catch (ex) {
       console.error(ex);
@@ -162,7 +167,6 @@ class Policy extends React.Component {
         });
       } else {
         const response = await this.policyService.add(policy);
-        console.log(response);
         history.push('/policies/browser');
       }
     } catch (ex) {
@@ -215,13 +219,26 @@ class Policy extends React.Component {
                 disabled={edit}
                 id="policy-name"
                 error={nameError}
-                helperText=""
-                label="Policy name"
+                helperText="Required. May only contain letters, digits and underscores. It may not end with an underscore."
+                label="Policy Name (ID)"
                 className={classes.textField}
                 value={this.state.policy.name}
                 onChange={this.handleChange('name')}
                 margin="none"
                 autoFocus
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+
+              <TextField
+                id="policy-displayname"
+                helperText="Optional. Text to display instead of Name (ID)"
+                label="Policy Displayname (optional)"
+                className={classes.textField}
+                value={this.state.policy.displayname}
+                onChange={this.handleChange('displayname')}
+                margin="none"
                 InputLabelProps={{
                   shrink: true,
                 }}
@@ -245,8 +262,8 @@ class Policy extends React.Component {
                   }}
                 >
                   {map(schedules, (schedule) => (
-                    <option key={schedule} value={schedule}>
-                      {schedule}
+                    <option key={schedule.name} value={schedule.name}>
+                      {schedule.displayName || schedule.name}
                     </option>
                   ))}
                 </Select>
@@ -295,7 +312,13 @@ class Policy extends React.Component {
         </div>
       );
     } else {
-      return <div />;
+      return this.state.isLoading ? (
+        <AppPageContent>
+          <CircularProgress />
+        </AppPageContent>
+      ) : (
+        <div />
+      );
     }
   }
 }

--- a/client/src/pages/Policy/PolicyList.js
+++ b/client/src/pages/Policy/PolicyList.js
@@ -80,8 +80,12 @@ class PolicyList extends React.Component {
 
       const policies =
         order === 'desc'
-          ? prevState.policies.sort((a, b) => (b < a ? -1 : 1))
-          : prevState.policies.sort((a, b) => (a < b ? -1 : 1));
+          ? prevState.policies.sort((a, b) =>
+              b.displayname || b.name < a.displayname || a.name ? -1 : 1
+            )
+          : prevState.policies.sort((a, b) =>
+              a.displayname || a.name < b.displayname || b.name ? -1 : 1
+            );
 
       return {
         policies,
@@ -110,11 +114,11 @@ class PolicyList extends React.Component {
 
   handleClick = (event, policy) => {
     const { selected } = this.state;
-    const selectedIndex = indexOf(selected, policy);
+    const selectedIndex = indexOf(selected, policy.name);
     let newSelected = [];
 
     if (selectedIndex === -1) {
-      newSelected = newSelected.concat(selected, policy);
+      newSelected = newSelected.concat(selected, policy.name);
     } else if (selectedIndex === 0) {
       newSelected = newSelected.concat(selected.slice(1));
     } else if (selectedIndex === selected.length - 1) {
@@ -131,7 +135,7 @@ class PolicyList extends React.Component {
 
   handleSelectAllClick = (event, checked) => {
     if (checked) {
-      this.setState({ selected: this.state.policies });
+      this.setState({ selected: this.state.policies.map((p) => p.name) });
     } else {
       this.setState({ selected: [] });
     }
@@ -256,14 +260,14 @@ class PolicyList extends React.Component {
                 </TableRow>
               ) : (
                 map(policies, (policy) => {
-                  const isSelected = indexOf(selected, policy) !== -1;
+                  const isSelected = indexOf(selected, policy.name) !== -1;
                   return (
                     <TableRow
                       hover
                       role="checkbox"
                       aria-checked={isSelected}
                       tabIndex={-1}
-                      key={policy}
+                      key={policy.name}
                       selected={isSelected}
                     >
                       <TableCell
@@ -279,11 +283,11 @@ class PolicyList extends React.Component {
                       <TableCell>
                         <span
                           onClick={this.handleClickNavigate(
-                            `/policies/browser/${policy}`
+                            `/policies/browser/${policy.name}`
                           )}
                           className={classes.link}
                         >
-                          {policy}
+                          {policy.displayName || policy.name}
                         </span>
                       </TableCell>
                     </TableRow>

--- a/client/src/pages/Schedule/ScheduleCreate.js
+++ b/client/src/pages/Schedule/ScheduleCreate.js
@@ -26,6 +26,7 @@ const styles = (theme) => ({
   textField: {
     minWidth: 250,
     marginBottom: theme.spacing(3),
+    marginRight: theme.spacing(2),
   },
 });
 
@@ -116,13 +117,23 @@ class ScheduleCreate extends React.Component {
           <TextField
             id="schedule-name"
             error={nameError}
-            helperText=""
-            placeholder="Schedule name"
+            helperText="Required. May only contain letters, digits and underscores. It may not end with an underscore."
+            placeholder="Schedule Name (ID)"
             className={classes.textField}
             value={schedule.name}
             onChange={this.handleChange('name')}
             margin="none"
             autoFocus
+          />
+
+          <TextField
+            id="schedule-displayname"
+            helperText="Optional. Text to display instead of Schedule Name (ID)"
+            placeholder="Schedule Displayname"
+            className={classes.textField}
+            value={schedule.displayname}
+            onChange={this.handleChange('displayname')}
+            margin="none"
           />
 
           <ScheduleTimeZone

--- a/client/src/pages/Schedule/ScheduleEdit.js
+++ b/client/src/pages/Schedule/ScheduleEdit.js
@@ -23,7 +23,7 @@ const styles = (theme) => ({
     marginRight: theme.spacing(2),
   },
   textField: {
-    width: 250,
+    width: 350,
     marginBottom: theme.spacing(3),
   },
 });
@@ -51,6 +51,12 @@ class ScheduleEdit extends React.Component {
       console.error(ex);
     }
   }
+
+  handleChange = (name) => (event) => {
+    const { schedule } = this.state;
+    schedule[name] = event.target.value;
+    this.setState({ schedule });
+  };
 
   handleScheduleChange = (nextSchedule) => {
     this.setState({
@@ -105,7 +111,17 @@ class ScheduleEdit extends React.Component {
               disabled
               id="schedule-name"
               className={classes.textField}
+              label="Schedule Name (ID)"
               value={schedule.name}
+              margin="none"
+            />
+
+            <TextField
+              id="schedule-displayname"
+              className={classes.textField}
+              value={schedule.displayname}
+              label="Schedule Display-Name"
+              onChange={this.handleChange('displayname')}
               margin="none"
             />
 

--- a/client/src/pages/Schedule/ScheduleList.js
+++ b/client/src/pages/Schedule/ScheduleList.js
@@ -146,7 +146,7 @@ class ScheduleList extends React.Component {
       if (selected.length > 0) {
         const promises = [];
         selected.forEach((schedule) => {
-          promises.push(this.scheduleService.delete(schedule.name));
+          promises.push(this.scheduleService.delete(schedule));
         });
         const responses = await Promise.all(promises);
         console.log(responses);

--- a/client/src/pages/Schedule/ScheduleList.js
+++ b/client/src/pages/Schedule/ScheduleList.js
@@ -79,8 +79,12 @@ class ScheduleList extends React.Component {
 
       const schedules =
         order === 'desc'
-          ? prevState.schedules.sort((a, b) => (b < a ? -1 : 1))
-          : prevState.schedules.sort((a, b) => (a < b ? -1 : 1));
+          ? prevState.schedules.sort((a, b) =>
+              b.displayname || b.name < a.displayname || a.name ? -1 : 1
+            )
+          : prevState.schedules.sort((a, b) =>
+              a.displayname || a.name < b.displayname || b.name ? -1 : 1
+            );
 
       return {
         schedules,
@@ -109,11 +113,11 @@ class ScheduleList extends React.Component {
 
   handleClick = (event, schedule) => {
     const { selected } = this.state;
-    const selectedIndex = indexOf(selected, schedule);
+    const selectedIndex = indexOf(selected, schedule.name);
     let newSelected = [];
 
     if (selectedIndex === -1) {
-      newSelected = newSelected.concat(selected, schedule);
+      newSelected = newSelected.concat(selected, schedule.name);
     } else if (selectedIndex === 0) {
       newSelected = newSelected.concat(selected.slice(1));
     } else if (selectedIndex === selected.length - 1) {
@@ -130,7 +134,7 @@ class ScheduleList extends React.Component {
 
   handleSelectAllClick = (event, checked) => {
     if (checked) {
-      this.setState({ selected: this.state.schedules });
+      this.setState({ selected: this.state.schedules.map((p) => p.name) });
     } else {
       this.setState({ selected: [] });
     }
@@ -142,7 +146,7 @@ class ScheduleList extends React.Component {
       if (selected.length > 0) {
         const promises = [];
         selected.forEach((schedule) => {
-          promises.push(this.scheduleService.delete(schedule));
+          promises.push(this.scheduleService.delete(schedule.name));
         });
         const responses = await Promise.all(promises);
         console.log(responses);
@@ -255,14 +259,14 @@ class ScheduleList extends React.Component {
                 </TableRow>
               ) : (
                 map(schedules, (schedule) => {
-                  const isSelected = indexOf(selected, schedule) !== -1;
+                  const isSelected = indexOf(selected, schedule.name) !== -1;
                   return (
                     <TableRow
                       hover
                       role="checkbox"
                       aria-checked={isSelected}
                       tabIndex={-1}
-                      key={schedule}
+                      key={schedule.name}
                       selected={isSelected}
                     >
                       <TableCell
@@ -278,11 +282,11 @@ class ScheduleList extends React.Component {
                       <TableCell>
                         <span
                           onClick={this.handleClickNavigate(
-                            `/schedules/browser/${schedule}`
+                            `/schedules/browser/${schedule.name}`
                           )}
                           className={classes.link}
                         >
-                          {schedule}
+                          {schedule.displayName || schedule.name}
                         </span>
                       </TableCell>
                     </TableRow>

--- a/main.py
+++ b/main.py
@@ -122,8 +122,7 @@ def list_schedules():
     schedules_list = []
     with client.context():
         verbose = request.args.get("verbose") == "true"
-        if (verbose):
-            schedules = SchedulesModel.query().fetch(keys_only=False)
+            schedules = SchedulesModel.query().fetch()
             for schedule in schedules:
                 schedules_list.append(
                     {"name": schedule.Name, "displayName": schedule.DisplayName}
@@ -215,8 +214,7 @@ def list_policies():
     policies_list = []
     with client.context():
         verbose = request.args.get("verbose") == "true"
-        if (verbose):
-            policies = PolicyModel.query().fetch(keys_only=False)
+            policies = PolicyModel.query().fetch()
             for policy in policies:
                 policies_list.append(
                     {"name": policy.Name, "displayName": policy.DisplayName}

--- a/main.py
+++ b/main.py
@@ -84,6 +84,7 @@ def add_schedule():
         }
 
         schedules_model.Name = request.json["name"]
+        schedules_model.DisplayName = request.json["displayname"] or request.json["name"]
         schedules_model.Timezone = request.json["timezone"]
         schedules_model.key = ndb.Key("SchedulesModel", request.json["name"])
         schedules_model.put()
@@ -104,6 +105,7 @@ def get_schedule():
         if not res:
             return "not found", 404
         schedule.update({"name": res.Name})
+        schedule.update({"displayname": res.DisplayName or res.Name})
         schedule.update(res.Schedule)
         schedule.update({"timezone": res.Timezone})
         logging.debug(json.dumps(res.Schedule))
@@ -119,9 +121,17 @@ def list_schedules():
     """
     schedules_list = []
     with client.context():
-        keys = SchedulesModel.query().fetch(keys_only=True)
-        for key in keys:
-            schedules_list.append(key.id())
+        verbose = request.args.get("verbose") == "true"
+        if (verbose):
+            schedules = SchedulesModel.query().fetch(keys_only=False)
+            for schedule in schedules:
+                schedules_list.append(
+                    {"name": schedule.Name, "displayName": schedule.DisplayName}
+                )
+        else:
+            keys = SchedulesModel.query().fetch(keys_only=True)
+            for key in keys:
+                schedules_list.append(key.id())
     return json.dumps(schedules_list)
 
 
@@ -153,6 +163,7 @@ def add_policy():
     """
     logging.debug(json.dumps(request.json))
     name = request.json["name"]
+    display_name = request.json["displayname"] or name
     tags = request.json["tags"]
     projects = request.json["projects"]
     schedule_name = request.json["schedulename"]
@@ -163,6 +174,7 @@ def add_policy():
 
         policy_model = PolicyModel()
         policy_model.Name = name
+        policy_model.DisplayName = display_name
         policy_model.Tags = tags
         policy_model.Projects = projects
         policy_model.Schedule = schedule_name
@@ -186,6 +198,7 @@ def get_policy():
         if not res:
             return "not found", 404
         policy.update({"name": res.Name})
+        policy.update({"displayname": res.DisplayName or res.Name})
         policy.update({"schedulename": res.Schedule})
         policy.update({"tags": res.Tags})
         policy.update({"projects": res.Projects})
@@ -201,9 +214,18 @@ def list_policies():
     """
     policies_list = []
     with client.context():
-        keys = PolicyModel.query().fetch(keys_only=True)
-        for key in keys:
-            policies_list.append(key.id())
+        verbose = request.args.get("verbose") == "true"
+        if (verbose):
+            policies = PolicyModel.query().fetch(keys_only=False)
+            for policy in policies:
+                policies_list.append(
+                    {"name": policy.Name, "displayName": policy.DisplayName}
+                )
+        else:
+            keys = PolicyModel.query().fetch(keys_only=True)
+            for key in keys:
+                policies_list.append(key.id())
+
     return json.dumps(policies_list)
 
 

--- a/main.py
+++ b/main.py
@@ -84,7 +84,8 @@ def add_schedule():
         }
 
         schedules_model.Name = request.json["name"]
-        schedules_model.DisplayName = request.json["displayname"] or request.json["name"]
+        schedules_model.DisplayName = request.json.get(
+            "displayname", request.json.get("name"))
         schedules_model.Timezone = request.json["timezone"]
         schedules_model.key = ndb.Key("SchedulesModel", request.json["name"])
         schedules_model.put()
@@ -162,7 +163,7 @@ def add_policy():
     """
     logging.debug(json.dumps(request.json))
     name = request.json["name"]
-    display_name = request.json["displayname"] or name
+    display_name = request.json.get("displayname", name)
     tags = request.json["tags"]
     projects = request.json["projects"]
     schedule_name = request.json["schedulename"]

--- a/main.py
+++ b/main.py
@@ -123,6 +123,7 @@ def list_schedules():
     schedules_list = []
     with client.context():
         verbose = request.args.get("verbose") == "true"
+        if verbose:
             schedules = SchedulesModel.query().fetch()
             for schedule in schedules:
                 schedules_list.append(
@@ -215,6 +216,7 @@ def list_policies():
     policies_list = []
     with client.context():
         verbose = request.args.get("verbose") == "true"
+        if verbose:
             policies = PolicyModel.query().fetch()
             for policy in policies:
                 policies_list.append(

--- a/model/policymodel.py
+++ b/model/policymodel.py
@@ -5,6 +5,7 @@ from google.cloud import ndb
 class PolicyModel(ndb.Model):
     """Class that represents a tags and their associated schedule."""
     Name = ndb.StringProperty(indexed=True, required=True)
+    DisplayName = ndb.JsonProperty(indexed=True, required=False, repeated=False)
     Tags = ndb.JsonProperty(repeated=True)
     Projects = ndb.JsonProperty(repeated=True)
     Schedule = ndb.StringProperty(indexed=True, required=True, repeated=False)

--- a/model/policymodel.py
+++ b/model/policymodel.py
@@ -5,7 +5,7 @@ from google.cloud import ndb
 class PolicyModel(ndb.Model):
     """Class that represents a tags and their associated schedule."""
     Name = ndb.StringProperty(indexed=True, required=True)
-    DisplayName = ndb.JsonProperty(indexed=True, required=False, repeated=False)
+    DisplayName = ndb.JsonProperty(indexed=True)
     Tags = ndb.JsonProperty(repeated=True)
     Projects = ndb.JsonProperty(repeated=True)
     Schedule = ndb.StringProperty(indexed=True, required=True, repeated=False)

--- a/model/schedulesmodel.py
+++ b/model/schedulesmodel.py
@@ -8,7 +8,7 @@ from util import tz
 class SchedulesModel(ndb.Model):
     """Stores scheduling data."""
     Name = ndb.StringProperty(indexed=True, required=True)
-    DisplayName = ndb.StringProperty(indexed=True, required=False)
+    DisplayName = ndb.StringProperty(indexed=True)
     Timezone = ndb.StringProperty(
         default='UTC', choices=tz.get_all_timezones(), required=True)
     Schedule = ndb.JsonProperty(required=True)

--- a/model/schedulesmodel.py
+++ b/model/schedulesmodel.py
@@ -8,6 +8,7 @@ from util import tz
 class SchedulesModel(ndb.Model):
     """Stores scheduling data."""
     Name = ndb.StringProperty(indexed=True, required=True)
+    DisplayName = ndb.StringProperty(indexed=True, required=False)
     Timezone = ndb.StringProperty(
         default='UTC', choices=tz.get_all_timezones(), required=True)
     Schedule = ndb.JsonProperty(required=True)


### PR DESCRIPTION
This PR (rather crudely) adds gui support for a `displayName` field to both policies and schedules, which can be used to display (and update) descriptions of the resources with less restrictions then what name offers (since the latter is used to form a record ID in the DB).

It introduces an optional parameter `verbose` to both `list_*` api calls to return an object with both name and displayname instead of just the name. 

It also adds some descriptions to the form fields which should also help with #107, and makes them larger to make space for the quite lengthy help texts.

Fixes #59 
