### PR TITLE
Feat/compute filter out gke nodes

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -2,6 +2,11 @@
   "extends": "react-app",
   "plugins": ["prettier"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": [
+              "error",
+              {
+                "endOfLine": "auto"
+              },
+            ]
   }
 }

--- a/gcp/compute.py
+++ b/gcp/compute.py
@@ -29,7 +29,7 @@ class Compute(object):
         Returns:
 
         """
-        tag_filter = "labels." + tagkey + "=" + tagvalue
+        tag_filter = "labels." + tagkey + "=" + tagvalue + " NOT labels.goog-gke-node=*"
         logging.debug("Filter %s", filter)
         for zone in gcp.get_zones():
             try:


### PR DESCRIPTION
Hi,

We recently updated the .eslintrc configuration to work with Windows end of line, issueing a yarn build command on the client folder would otherwise result in a error like the following: "Line 35:1:   Delete `␍`  prettier/prettier".

On the compute file we appended a string on the _tag_filter_ expression to filter out compute instances belonging to one GKE cluster (node pool). This is useful in case one or more labels matching a Zorya policy are assigned both to the cluster and to the node pool. In this very specific case we noticed an error when Zorya tries to stop instances belonging to the Node Pool MIG which results in the latter destroying and recreating those instances and an overall failure in shutting down GKE cluster nodes.

The real problem is due to Zorya not being able to manage GCP MIG. The compute _change_status_ method should not consider instances belonging to Managed Instance Group since, as I said before, "instance stop" is not possible for those VMs. We dind't find a simple way to filter out instances belonging to MIG since this information is available in the metadata field but this field is not managed (from official Google documentation) in the compute list filter options. 